### PR TITLE
Add collapsible nodes to canvas

### DIFF
--- a/src/modules/canvas/Canvas.tsx
+++ b/src/modules/canvas/Canvas.tsx
@@ -23,6 +23,8 @@ export const Canvas = () => {
     setEdges,
     onEdgesChange,
     addQuestNode,
+    collapseAll,
+    expandAll,
   } = useCanvasGraph(); // This hook can be used to manage nodes and edges if needed
 
   const onConnect = useConnectionHandler(setEdges);
@@ -66,6 +68,8 @@ export const Canvas = () => {
         cursorMode={cursorMode}
         setCursorMode={setCursorMode}
         setViewMode={setViewMode}
+        collapseAll={collapseAll}
+        expandAll={expandAll}
       ></CanvasView>
     </div>
   );

--- a/src/modules/canvas/canvas.type.ts
+++ b/src/modules/canvas/canvas.type.ts
@@ -5,6 +5,8 @@ export type FloatingToolboxProps = {
   cursorMode: CursorModeType;
   setCursorMode: (mode: CursorModeType) => void;
   setViewMode: (mode: ViewModeType) => void;
+  collapseAll: () => void;
+  expandAll: () => void;
 };
 
 export type SkillConfigType = {

--- a/src/modules/canvas/components/CanvasView.tsx
+++ b/src/modules/canvas/components/CanvasView.tsx
@@ -31,6 +31,8 @@ type CanvasViewProps = {
   cursorMode: CursorModeType;
   setCursorMode: (mode: CursorModeType) => void;
   setViewMode: React.Dispatch<React.SetStateAction<ViewModeType>>;
+  collapseAll: () => void;
+  expandAll: () => void;
 };
 
 const nodeTypes = {
@@ -53,6 +55,8 @@ export const CanvasView = ({
   cursorMode,
   setCursorMode,
   setViewMode,
+  collapseAll,
+  expandAll,
 }: CanvasViewProps) => (
   <ReactFlow
     nodes={nodes}
@@ -100,6 +104,8 @@ export const CanvasView = ({
       cursorMode={cursorMode}
       setCursorMode={setCursorMode}
       setViewMode={setViewMode}
+      collapseAll={collapseAll}
+      expandAll={expandAll}
     />
   </ReactFlow>
 );

--- a/src/modules/canvas/components/FloatingToolbox.tsx
+++ b/src/modules/canvas/components/FloatingToolbox.tsx
@@ -6,6 +6,8 @@ export const FloatingToolbox = ({
   cursorMode,
   setCursorMode,
   setViewMode,
+  collapseAll,
+  expandAll,
 }: FloatingToolboxProps) => (
   <div className="absolute top-6 right-6 z-20 bg-white/90 backdrop-blur-sm rounded-xl shadow-lg border border-gray-200/50 p-2 flex flex-col gap-1">
     {/* Quest Creation Tool */}
@@ -75,6 +77,7 @@ export const FloatingToolbox = ({
     {/* Collapse/Expand quest Tools */}
     <div className="group relative">
       <Button
+        onClick={collapseAll}
         variant="ghost"
         size="sm"
         className="w-10 h-10 p-0 rounded-lg hover:bg-gray-100 transition-all duration-200"
@@ -88,6 +91,7 @@ export const FloatingToolbox = ({
 
     <div className="group relative">
       <Button
+        onClick={expandAll}
         variant="ghost"
         size="sm"
         className="w-10 h-10 p-0 rounded-lg hover:bg-gray-100 transition-all duration-200"

--- a/src/modules/canvas/components/QuestNode.tsx
+++ b/src/modules/canvas/components/QuestNode.tsx
@@ -1,4 +1,5 @@
 import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { ChevronUp, ChevronDown } from "lucide-react";
 
 import type { QuestNodeData } from "../canvas.type";
 import { useRef } from "react";
@@ -13,12 +14,64 @@ export const QuestNode = ({ id, data }: NodeProps<Node<QuestNodeData>>) => {
     data.onDelete?.(id);
   };
 
+  const toggleCollapse = () => {
+    data.onUpdate?.("isCollapsed", !data.isCollapsed);
+  };
+
+  if (data.isCollapsed) {
+    return (
+      <div ref={blackHoleRef}>
+        <div
+          ref={nodeRef}
+          className="relative rounded-xl p-4 bg-yellow-300/30 border border-yellow-400 shadow-md"
+        >
+          <Handle
+            type="target"
+            position={Position.Top}
+            className="w-3 h-3 bg-yellow-400"
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            className="w-3 h-3 bg-yellow-400"
+          />
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleCollapse();
+            }}
+            className="absolute top-1 right-1 bg-white/20 rounded p-1"
+          >
+            <ChevronDown className="w-4 h-4" />
+          </button>
+          <div className="text-yellow-900 font-semibold text-center">
+            {data.title}
+          </div>
+          {data.childCount !== undefined && (
+            <div className="text-xs text-yellow-800 text-center">
+              {data.childCount}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div ref={blackHoleRef}>
       <div
         ref={nodeRef}
         className="relative rounded-3xl p-8 shadow-[0_0_40px_rgba(0,255,255,0.25)] border-2 border-cyan-400/60 z-10 ring-4 ring-cyan-300/10 bg-cover max-h-[560px]"
       >
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleCollapse();
+          }}
+          className="absolute top-4 right-16 z-20 bg-white/20 rounded p-1"
+        >
+          <ChevronUp className="w-4 h-4" />
+        </button>
         <QuestCard
           data={data}
           onDelete={handleDelete}

--- a/src/modules/canvas/hooks/useCanvasGraph.ts
+++ b/src/modules/canvas/hooks/useCanvasGraph.ts
@@ -15,6 +15,16 @@ export const useCanvasGraph = () => {
   const [nodes, setNodes, onNodesChange] =
     useNodesState<Node<QuestNodeData | SkillNodeData>>(initialNodes);
 
+  const updateNodeData = (id: string, field: string, value: any) => {
+    setNodes((prev) =>
+      prev.map((n) =>
+        n.id === id
+          ? { ...n, data: { ...(n.data as any), [field]: value } }
+          : n,
+      ),
+    );
+  };
+
   const addQuestNode = (position: XYPosition) => {
     const id = `quest-${Date.now()}`; // to change
 
@@ -29,8 +39,11 @@ export const useCanvasGraph = () => {
         description: "Quest description...",
         status: "not-started",
         type: "side",
+        isCollapsed: false,
         onDelete: (id: string) =>
           setNodes((prev) => prev.filter((n) => n.id !== id)),
+        onUpdate: (field: string, value: any) =>
+          updateNodeData(id, field, value),
       },
     };
 
@@ -39,6 +52,26 @@ export const useCanvasGraph = () => {
 
   const deleteNode = (id: string) => {
     setNodes((prev) => prev.filter((n) => n.id !== id));
+  };
+
+  const collapseAll = () => {
+    setNodes((prev) =>
+      prev.map((n) =>
+        n.type === "quest1"
+          ? { ...n, data: { ...(n.data as any), isCollapsed: true } }
+          : n,
+      ),
+    );
+  };
+
+  const expandAll = () => {
+    setNodes((prev) =>
+      prev.map((n) =>
+        n.type === "quest1"
+          ? { ...n, data: { ...(n.data as any), isCollapsed: false } }
+          : n,
+      ),
+    );
   };
 
   return {
@@ -50,5 +83,7 @@ export const useCanvasGraph = () => {
     onEdgesChange,
     addQuestNode,
     deleteNode,
+    collapseAll,
+    expandAll,
   };
 };


### PR DESCRIPTION
## Summary
- let `useCanvasGraph` update node data and support collapsing nodes
- implement collapse logic in `QuestNode`
- connect collapse controls through `CanvasView` and `FloatingToolbox`
- expose global collapse/expand actions in the toolbox

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e9a5402ac8320b5a6afbb8f6ec6a9