### PR TITLE
Fix skills pages layout

### DIFF
--- a/src/component/header/DashboardHeader.tsx
+++ b/src/component/header/DashboardHeader.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/shared/components/ui/button";
 
 export const DashboardHeader = ({ coins }: DashboardHeaderProps) => {
   return (
-    <header className="ml-20 flex justify-end items-center px-6 py-4 border-b border-slate-700 shadow-lg bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+    <header className="flex justify-end items-center px-6 py-4 border-b border-slate-700 shadow-lg bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
       <nav className="flex items-center gap-4">
         <div className="flex items-center cursor-pointer gap-2 px-4 py-2 bg-yellow-500 hover:bg-yellow-400 hover:scale-105 text-black text-sm font-semibold rounded-lg transition-all duration-200 transform shadow-md">
           <Coins size={18} color="black" />

--- a/src/component/sidebar/Sidebar.tsx
+++ b/src/component/sidebar/Sidebar.tsx
@@ -9,7 +9,7 @@ export const Sidebar = () => {
     <div className="flex">
       <div
         className={`${
-          isCollapsed ? "w-20" : "w-65"
+          isCollapsed ? "w-20" : "w-64"
         } h-screen bg-slate-900 text-white fixed shadow-lg transition-all duration-300`}
       >
         <SidebarHeader />

--- a/src/pages/SkillDetail.tsx
+++ b/src/pages/SkillDetail.tsx
@@ -18,7 +18,7 @@ const SkillDetail = () => {
 
   if (!skill) {
     return (
-      <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-8">
+      <div className="flex items-center justify-center p-8 min-h-screen">
         <div className="text-center space-y-4">
           <div className="text-6xl">😕</div>
           <h1 className="text-2xl font-bold">Skill non trouvé</h1>
@@ -30,7 +30,7 @@ const SkillDetail = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-8">
+    <div className="p-8 space-y-6">
       {/* Header */}
       <div className="flex items-center gap-4 mb-6">
         <Button

--- a/src/pages/dashboard/DashboardLayout.tsx
+++ b/src/pages/dashboard/DashboardLayout.tsx
@@ -1,13 +1,20 @@
 import { DashboardHeader } from "@/component/header/DashboardHeader";
 import { Sidebar } from "@/component/sidebar/Sidebar";
 import { Outlet } from "react-router-dom";
+import { useSidebarStore } from "@/stores/sidebar/sidebarStore";
 
 export const DashboardLayout = () => {
+  const { isCollapsed } = useSidebarStore();
+
   return (
     <div>
       <Sidebar />
-      <DashboardHeader coins="500" />
-      <Outlet />
+      <div className={`transition-all duration-300 ${isCollapsed ? "ml-20" : "ml-64"}`}>
+        <DashboardHeader coins="500" />
+        <main className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-8">
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 };

--- a/src/pages/dashboard/Skills.tsx
+++ b/src/pages/dashboard/Skills.tsx
@@ -1,9 +1,5 @@
 import { SkillsList } from "@/modules/skills/components/SkillsList";
 
 export const Skills = () => {
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-8">
-      <SkillsList />
-    </div>
-  );
+  return <SkillsList />;
 };


### PR DESCRIPTION
## Summary
- update sidebar width and dashboard header margin
- move layout padding and background into `DashboardLayout`
- simplify skills page containers
- adjust skill detail wrapper styles

## Testing
- `npm run prettier`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bbe65ac90832080dc4999a3bd0145