### PR TITLE
Fix onboarding overlay positioning

### DIFF
--- a/src/modules/canvas/components/CanvasView.tsx
+++ b/src/modules/canvas/components/CanvasView.tsx
@@ -123,6 +123,7 @@ export const CanvasView = ({
 
       <div className="absolute top-6 right-32 z-20">
         <Button
+          data-tour-id="save"
           variant={isCanvasSaving ? "outline" : "default"}
           size="sm"
           aria-label="Save"

--- a/src/modules/canvas/components/QuestNode.tsx
+++ b/src/modules/canvas/components/QuestNode.tsx
@@ -22,6 +22,7 @@ export const QuestNode = ({ id, data }: NodeProps<Node<QuestNodeData>>) => {
     <div ref={blackHoleRef}>
       <div
         ref={nodeRef}
+        data-tour-id="quest-node"
         className="relative rounded-3xl p-8 shadow-[0_0_40px_rgba(0,255,255,0.25)] border-2 border-cyan-400/60 z-10 ring-4 ring-cyan-300/10 bg-cover max-h-[560px]"
       >
         <QuestCard
@@ -32,6 +33,7 @@ export const QuestNode = ({ id, data }: NodeProps<Node<QuestNodeData>>) => {
             <Handle
               type="target"
               position={Position.Top}
+              data-tour-id="handle"
               style={{ width: "20px", height: "20px" }}
               className="bg-gradient-to-r from-purple-700/30 via-yellow-100/20 to-purple-900/30 rounded-xl p-2 border-2 border-yellow-300/40 backdrop-blur-md mb-5 shadow-[0_2px_12px_2px_rgba(128,0,255,0.10)] hover:scale-110 transition-transform z-20"
             />
@@ -40,6 +42,7 @@ export const QuestNode = ({ id, data }: NodeProps<Node<QuestNodeData>>) => {
             <Handle
               type="source"
               position={Position.Bottom}
+              data-tour-id="handle"
               style={{ width: "20px", height: "20px" }}
               className="bg-gradient-to-br from-purple-700/30 via-yellow-100/20 to-purple-900/30 rounded-xl p-2 border-2 border-yellow-300/40 backdrop-blur-md shadow-[0_2px_12px_2px_rgba(128,0,255,0.10)] hover:scale-110 transition-transform z-20"
             />

--- a/src/modules/canvas/components/floating-toolbox/ToolButton.tsx
+++ b/src/modules/canvas/components/floating-toolbox/ToolButton.tsx
@@ -16,6 +16,7 @@ export const ToolButton = ({ tool, cursorMode, setCursorMode, colllapseAll, expa
   return (
     <div className="group relative">
       <Button
+        data-tour-id={tool.id}
         variant={`${active ? "default" : "ghost"}`}
         onClick={() =>
           tool.handleToolClick(setCursorMode, cursorMode, {

--- a/src/modules/canvas/components/onboarding/CanvasOnboarding.tsx
+++ b/src/modules/canvas/components/onboarding/CanvasOnboarding.tsx
@@ -1,0 +1,118 @@
+import { useLayoutEffect, useState } from "react";
+import { Button } from "@/shared/components/ui/button";
+import { useCanvasOnboardingStore } from "@/stores/onboarding-store";
+
+interface Step {
+  id: string;
+  target: string;
+  title: string;
+  description: string;
+}
+
+const steps: Step[] = [
+  {
+    id: "create",
+    target: '[data-tour-id="create"]',
+    title: "Créer une quête",
+    description: "Clique sur l'icône Plus pour ajouter une nouvelle quête.",
+  },
+  {
+    id: "handle",
+    target: '[data-tour-id="handle"]',
+    title: "Les points de connexion",
+    description: "Chaque quête possède des poignées pour la relier à d'autres.",
+  },
+  {
+    id: "connect",
+    target: '[data-tour-id="connect"]',
+    title: "Lier des quêtes",
+    description: "Active le mode connexion puis clique sur deux quêtes pour les relier.",
+  },
+  {
+    id: "save",
+    target: '[data-tour-id="save"]',
+    title: "Sauvegarder ton travail",
+    description: "Enregistre le canvas grâce au bouton Save.",
+  },
+];
+
+export const CanvasOnboarding = () => {
+  const [step, setStep] = useState(0);
+  const { setCompleted } = useCanvasOnboardingStore();
+  const [highlight, setHighlight] = useState<React.CSSProperties>();
+  const [dialog, setDialog] = useState<React.CSSProperties>();
+
+  const current = steps[step];
+
+  useLayoutEffect(() => {
+    const el = document.querySelector(current.target) as HTMLElement | null;
+    if (!el) {
+      setHighlight(undefined);
+      setDialog(undefined);
+      return;
+    }
+
+    const rect = el.getBoundingClientRect();
+
+    setHighlight({
+      top: rect.top - 6,
+      left: rect.left - 6,
+      width: rect.width + 12,
+      height: rect.height + 12,
+    });
+
+    const DIALOG_WIDTH = 288; // w-72
+    const DIALOG_HEIGHT = 160;
+
+    let left = rect.left + rect.width / 2;
+    left = Math.min(window.innerWidth - DIALOG_WIDTH / 2 - 12, Math.max(DIALOG_WIDTH / 2 + 12, left));
+
+    let top = rect.bottom + 12;
+    if (top + DIALOG_HEIGHT > window.innerHeight) {
+      top = rect.top - DIALOG_HEIGHT - 12;
+    }
+
+    setDialog({
+      top,
+      left,
+    });
+  }, [current.target]);
+
+  const next = () => {
+    if (step < steps.length - 1) {
+      setStep(step + 1);
+    } else {
+      setCompleted(true);
+    }
+  };
+
+  const skip = () => setCompleted(true);
+
+  return (
+    <div className="absolute inset-0 pointer-events-none z-50">
+      {highlight && (
+        <div
+          className="absolute rounded-xl border-4 border-pink-500 shadow-[0_0_20px_rgba(255,0,180,0.6)] animate-pulse"
+          style={highlight}
+        />
+      )}
+      {dialog && (
+        <div
+          className="absolute -translate-x-1/2 w-72 bg-[rgba(12,8,33,0.9)] border-2 border-pink-500 text-white rounded-xl p-4 space-y-3 shadow-xl pointer-events-auto"
+          style={dialog}
+        >
+          <h3 className="text-lg font-bold text-pink-300">{current.title}</h3>
+          <p className="text-sm leading-relaxed text-gray-100">{current.description}</p>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button size="sm" variant="ghost" onClick={skip}>
+              Ignorer
+            </Button>
+            <Button size="sm" onClick={next}>
+              {step < steps.length - 1 ? "Suivant" : "Terminer"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/modules/skills/components/Pagination.tsx
+++ b/src/modules/skills/components/Pagination.tsx
@@ -38,4 +38,4 @@ export function Pagination({ page, setPage, totalPages }: PaginationProps) {
       </button>
     </div>
   );
-} 
+}

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -1,10 +1,23 @@
 import { Canvas } from "@/modules/canvas/Canvas";
 import { ReactFlowProvider } from "@xyflow/react";
+import { CanvasOnboarding } from "@/modules/canvas/components/onboarding/CanvasOnboarding";
+import { useCanvasOnboardingStore } from "@/stores/onboarding-store";
+import { Button } from "@/shared/components/ui/button";
 
 export const CanvasPage = () => {
+  const { completed, reset } = useCanvasOnboardingStore();
+
   return (
-    <ReactFlowProvider>
-      <Canvas />
-    </ReactFlowProvider>
+    <div className="relative h-screen">
+      <ReactFlowProvider>
+        <Canvas />
+        <div className="absolute bottom-6 right-6 z-30">
+          <Button size="sm" variant="outline" onClick={reset}>
+            Rejouer le tutoriel
+          </Button>
+        </div>
+        {!completed && <CanvasOnboarding />}
+      </ReactFlowProvider>
+    </div>
   );
 };

--- a/src/stores/onboarding-store.ts
+++ b/src/stores/onboarding-store.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface CanvasOnboardingState {
+  completed: boolean;
+  setCompleted: (completed: boolean) => void;
+  reset: () => void;
+}
+
+export const useCanvasOnboardingStore = create<CanvasOnboardingState>()(
+  persist(
+    (set) => ({
+      completed: false,
+      setCompleted: (completed: boolean) => set({ completed }),
+      reset: () => set({ completed: false }),
+    }),
+    { name: "canvas-onboarding" },
+  ),
+);


### PR DESCRIPTION
## Summary
- clamp onboarding dialog position to viewport
- hide overlay when target is missing
- move tutorial replay button to bottom-right

## Testing
- `npm run prettier`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6870539d33088320bd4ff2ff156dcab2