### PR TITLE
Refactor canvas store separation

### DIFF
--- a/src/modules/canvas/Canvas.tsx
+++ b/src/modules/canvas/Canvas.tsx
@@ -10,7 +10,7 @@ import { CanvasView } from "./components/CanvasView";
 import { useSaveCanvas, useQuestsLoader } from "./hooks/useSaveCanvas";
 import { Toaster } from "@/shared/components/ui/sonner";
 import { useAutoSaveCanvas } from "./hooks/useAutoSaveCanvas";
-import { useQuestStore } from "@/stores/quest/quest-store";
+import { useCanvasStore } from "@/stores/canvas/canvas-store";
 import { useNavigate } from "react-router-dom";
 import { CreateSkillModal } from "@/modules/canvas/components/modal/CreateSkillModal";
 import { useSkillStore } from "@/stores/skill/skillStore";
@@ -27,7 +27,7 @@ export const Canvas = () => {
   const [connectionStart, setConnectionStart] = useState<string | null>(null);
   const [, setViewMode] = useState<ViewModeType>("canvas");
 
-  const { cursorMode, setCursorMode } = useQuestStore();
+  const { cursorMode, setCursorMode } = useCanvasStore();
   const { screenToFlowPosition } = useReactFlow();
 
   const { skill } = useSkillStore();

--- a/src/modules/canvas/components/QuestNode.tsx
+++ b/src/modules/canvas/components/QuestNode.tsx
@@ -3,13 +3,13 @@ import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
 import type { QuestNodeData } from "../canvas.type";
 import { useRef } from "react";
 import { QuestCard } from "./QuestCard";
-import { useQuestStore } from "@/stores/quest/quest-store";
+import { useCanvasStore } from "@/stores/canvas/canvas-store";
 
 export const QuestNode = ({ id, data }: NodeProps<Node<QuestNodeData>>) => {
   const nodeRef = useRef<HTMLDivElement>(null);
   const blackHoleRef = useRef<HTMLDivElement>(null);
-  const markDeletedNode = useQuestStore((state) => state.markDeletedNode);
-  const { cursorMode } = useQuestStore((state) => state);
+  const markDeletedNode = useCanvasStore((state) => state.markDeletedNode);
+  const { cursorMode } = useCanvasStore((state) => state);
   const isConnect = cursorMode === "connect";
 
   const handleDelete = () => {

--- a/src/modules/canvas/hooks/useCanvasGraph.ts
+++ b/src/modules/canvas/hooks/useCanvasGraph.ts
@@ -7,24 +7,24 @@ import {
   type XYPosition,
 } from "@xyflow/react";
 import type { QuestNodeData, SkillNodeData } from "../canvas.type";
-import { useQuestStore } from "@/stores/quest/quest-store";
+import { useCanvasStore } from "@/stores/canvas/canvas-store";
 import { useCallback } from "react";
 import type { Skill } from "@/shared/types/skill.type";
 
 // This hook manages the state of nodes and edges in the canvas graph.
 export const useCanvasGraph = () => {
-  const nodes = useQuestStore((state) => state.nodes);
-  const setNodes = useQuestStore((state) => state.setNodes);
-  const edges = useQuestStore((state) => state.edges);
-  const setEdges = useQuestStore((state) => state.setEdges);
-  const addNode = useQuestStore((state) => state.addNode);
-  const removeNode = useQuestStore((state) => state.removeNode);
-  const markModifiedNode = useQuestStore((state) => state.markModifiedNode);
-  const markNew = useQuestStore((state) => state.markNew);
+  const nodes = useCanvasStore((state) => state.nodes);
+  const setNodes = useCanvasStore((state) => state.setNodes);
+  const edges = useCanvasStore((state) => state.edges);
+  const setEdges = useCanvasStore((state) => state.setEdges);
+  const addNode = useCanvasStore((state) => state.addNode);
+  const removeNode = useCanvasStore((state) => state.removeNode);
+  const markModifiedNode = useCanvasStore((state) => state.markModifiedNode);
+  const markNew = useCanvasStore((state) => state.markNew);
 
   const updateNodeData = useCallback(
     (id: string, field: string, value: any) => {
-      const current = useQuestStore.getState().nodes;
+      const current = useCanvasStore.getState().nodes;
       const updated = current.map((n) => (n.id === id ? { ...n, data: { ...n.data, [field]: value } } : n));
       setNodes(updated);
       markModifiedNode(id);
@@ -95,7 +95,7 @@ export const useCanvasGraph = () => {
   };
 
   const collapseAll = useCallback(() => {
-    const storeNodes = useQuestStore.getState().nodes;
+    const storeNodes = useCanvasStore.getState().nodes;
     setNodes(
       storeNodes.map((node) =>
         node.type === "questNode" ? { ...node, data: { ...node.data, isCollapsed: true } } : node,

--- a/src/modules/canvas/hooks/useSaveCanvas.ts
+++ b/src/modules/canvas/hooks/useSaveCanvas.ts
@@ -3,7 +3,7 @@ import { type Node } from "@xyflow/react";
 import type { QuestNodeData, SkillNodeData } from "../canvas.type";
 import { useCreateQuests, useDeleteQuests, useGetQuests, useUpdateQuests } from "@/shared/services/quest/api-quest";
 import { useCallback, useEffect } from "react";
-import { useQuestStore } from "@/stores/quest/quest-store";
+import { useCanvasStore } from "@/stores/canvas/canvas-store";
 import { initialNodes } from "../canvas.const";
 import { showToast } from "@/component/notification/show-toast";
 import { useSkillStore } from "@/stores/skill/skillStore";
@@ -12,7 +12,7 @@ export const useSaveCanvas = () => {
   const { createQuest } = useCreateQuests();
   const { updateQuest } = useUpdateQuests();
   const { deleteQuest } = useDeleteQuests();
-  const { nodes, newIds, modifiedNodesIds, deletedNodesIds, clearFlags } = useQuestStore();
+  const { nodes, newIds, modifiedNodesIds, deletedNodesIds, clearFlags } = useCanvasStore();
   const { skill } = useSkillStore();
 
   // type guard to check if a node is a QuestNode
@@ -91,13 +91,13 @@ export const useSaveCanvas = () => {
 
 export const useQuestsLoader = (skillId: string) => {
   const { quests, loading, error } = useGetQuests(skillId);
-  const setNodes = useQuestStore((state) => state.setNodes);
-  const removeNode = useQuestStore((state) => state.removeNode);
-  const markModifiedNode = useQuestStore((state) => state.markModifiedNode);
+  const setNodes = useCanvasStore((state) => state.setNodes);
+  const removeNode = useCanvasStore((state) => state.removeNode);
+  const markModifiedNode = useCanvasStore((state) => state.markModifiedNode);
 
   const updateNodeData = useCallback(
     (id: string, field: string, value: any) => {
-      const current = useQuestStore.getState().nodes;
+      const current = useCanvasStore.getState().nodes;
       const updated = current.map((n) => (n.id === id ? { ...n, data: { ...n.data, [field]: value } } : n));
       setNodes(updated);
       markModifiedNode(id);

--- a/src/stores/canvas/canvas-store.ts
+++ b/src/stores/canvas/canvas-store.ts
@@ -1,14 +1,80 @@
+import { type Edge, type Node } from "@xyflow/react";
+import type { CursorModeType, QuestNodeData, SkillNodeData } from "@/modules/canvas/canvas.type";
+import { create } from "zustand";
 import { useSkillStore } from "@/stores/skill/skillStore";
 import { useQuestStore } from "../quest/quest-store";
-import { create } from "zustand";
 
 type CanvasStore = {
+  nodes: Node<QuestNodeData | SkillNodeData>[];
+  edges: Edge[];
+  newIds: string[];
+  modifiedNodesIds: string[];
+  deletedNodesIds: string[];
+  cursorMode: CursorModeType;
+
+  setNodes: (nodes: Node<QuestNodeData | SkillNodeData>[]) => void;
+  setEdges: (edges: Edge[]) => void;
+  setCursorMode: (mode: CursorModeType) => void;
+
+  markModifiedNode: (id: string) => void;
+  markNew: (id: string) => void;
+  markDeletedNode: (id: string) => void;
+  clearFlags: () => void;
+
+  addNode: (node: Node<QuestNodeData | SkillNodeData>) => void;
+  removeNode: (id: string) => void;
+  reset: () => void;
   resetCanvasStore: () => void;
 };
 
-export const useCanvasStore = create<CanvasStore>(() => ({
+export const useCanvasStore = create<CanvasStore>((set) => ({
+  nodes: [],
+  edges: [],
+  newIds: [],
+  modifiedNodesIds: [],
+  deletedNodesIds: [],
+  cursorMode: "normal",
+
+  setNodes: (nodes) => set({ nodes }),
+  setEdges: (edges) => set({ edges }),
+  setCursorMode: (mode) => set({ cursorMode: mode }),
+
+  markModifiedNode: (id) =>
+    set((state) => ({
+      modifiedNodesIds: state.modifiedNodesIds.includes(id) ? state.modifiedNodesIds : [...state.modifiedNodesIds, id],
+    })),
+  markNew: (id) =>
+    set((state) => ({
+      newIds: state.newIds.includes(id) ? state.newIds : [...state.newIds, id],
+    })),
+  markDeletedNode: (id) =>
+    set((state) => ({
+      deletedNodesIds: state.deletedNodesIds.includes(id) ? state.deletedNodesIds : [...state.deletedNodesIds, id],
+    })),
+  clearFlags: () => set({ modifiedNodesIds: [], newIds: [], deletedNodesIds: [] }),
+
+  addNode: (node) => set((state) => ({ nodes: [...state.nodes, node] })),
+  removeNode: (id) => set((state) => ({ nodes: state.nodes.filter((n) => n.id !== id) })),
+
+  reset: () =>
+    set({
+      nodes: [],
+      edges: [],
+      newIds: [],
+      modifiedNodesIds: [],
+      deletedNodesIds: [],
+    }),
+
   resetCanvasStore: () => {
     useQuestStore.getState().reset();
     useSkillStore.getState().reset();
+    set({
+      nodes: [],
+      edges: [],
+      newIds: [],
+      modifiedNodesIds: [],
+      deletedNodesIds: [],
+      cursorMode: "normal",
+    });
   },
 }));

--- a/src/stores/quest/quest-store.ts
+++ b/src/stores/quest/quest-store.ts
@@ -1,81 +1,24 @@
-import { type Edge, type Node } from "@xyflow/react";
-import type { CursorModeType, QuestNodeData, SkillNodeData } from "@/modules/canvas/canvas.type";
 import type { Quest } from "@/shared/types/quest.type";
 import { create } from "zustand";
 
 type QuestStore = {
   quests: Quest[];
-  nodes: Node<QuestNodeData | SkillNodeData>[];
-  newIds: string[];
-  modifiedNodesIds: string[];
-  deletedNodesIds: string[];
-  edges: Edge[];
-  cursorMode: CursorModeType;
-
-  setNodes: (nodes: Node<QuestNodeData | SkillNodeData>[]) => void; // to set the updated array of nodes in the store
-  setEdges: (edges: Edge[]) => void;
-
-  setCursorMode: (mode: CursorModeType) => void;
-
-  markModifiedNode: (id: string) => void; // to mark a node as modified
-  markNew: (id: string) => void; // to mark a node as new
-  markDeletedNode: (id: string) => void; // to mark a node as deleted
-  clearFlags: () => void; // to clear modified and new flags
-
-  addNode: (node: Node<QuestNodeData | SkillNodeData>) => void; // to add a new node to the store
-  removeNode: (id: string) => void;
-  removeAllQuests: () => void;
+  setQuests: (quests: Quest[]) => void;
+  addQuest: (quest: Quest) => void;
+  removeQuest: (id: string) => void;
   reset: () => void;
 };
 
 export const useQuestStore = create<QuestStore>((set) => ({
   quests: [],
-  nodes: [],
-  modifiedNodesIds: [],
-  newIds: [],
-  deletedNodesIds: [],
-  edges: [],
-
-  cursorMode: "normal",
-  setCursorMode: (mode: CursorModeType) => set({ cursorMode: mode }),
-
-  setNodes: (nodes) => set({ nodes }),
-  setEdges: (edges) => set({ edges }),
-
-  markModifiedNode: (id: string) =>
+  setQuests: (quests) => set({ quests }),
+  addQuest: (quest) =>
     set((state) => ({
-      modifiedNodesIds: state.modifiedNodesIds.includes(id) ? state.modifiedNodesIds : [...state.modifiedNodesIds, id],
+      quests: [...state.quests, quest],
     })),
-
-  markNew: (id: string) =>
+  removeQuest: (id: string) =>
     set((state) => ({
-      newIds: state.newIds.includes(id) ? state.newIds : [...state.newIds, id],
+      quests: state.quests.filter((q) => q.id !== id),
     })),
-
-  markDeletedNode: (id: string) =>
-    set((state) => ({
-      deletedNodesIds: state.deletedNodesIds.includes(id) ? state.deletedNodesIds : [...state.deletedNodesIds, id],
-    })),
-
-  clearFlags: () => set({ modifiedNodesIds: [], newIds: [], deletedNodesIds: [] }),
-
-  addNode: (node) =>
-    set((state) => ({
-      nodes: [...state.nodes, node],
-    })),
-
-  removeNode: (id: string) =>
-    set((state) => ({
-      nodes: state.nodes.filter((node) => node.id !== id),
-    })),
-  removeAllQuests: () => set({ quests: [] }),
-
-  reset: () =>
-    set({
-      quests: [],
-      nodes: [],
-      modifiedNodesIds: [],
-      newIds: [],
-      edges: [],
-    }),
+  reset: () => set({ quests: [] }),
 }));


### PR DESCRIPTION
## Summary
- split quest store logic from canvas store
- manage canvas data (nodes, edges, flags) inside new canvas-store
- update hooks and components to use the new store

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68756835bd0883208782c53bd3738f9e