### PR TITLE
Add auto generation UI

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,5 +1,6 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
+  readonly VITE_GOOGLE_GENAI_API_KEY: string;
 }
 
 interface ImportMeta {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "sonner": "^2.0.2",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10",
-        "zustand": "^5.0.6"
+        "zustand": "^5.0.6",
+        "@google/genai": "^0.5.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "sonner": "^2.0.2",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "@google/genai": "^0.5.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/src/modules/canvas/Canvas.tsx
+++ b/src/modules/canvas/Canvas.tsx
@@ -13,6 +13,8 @@ import { useAutoSaveCanvas } from "./hooks/useAutoSaveCanvas";
 import { useCanvasStore } from "@/stores/quest/canvas-store";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { CreateSkillModal } from "./components/CreateSkillModal";
+import { AIGenerateModal } from "./components/AIGenerateModal";
+import { generateSkillWithQuests } from "@/shared/services/google-genai.service";
 import type { Skill } from "@/shared/types/skill.type";
 
 export const Canvas = () => {
@@ -23,6 +25,9 @@ export const Canvas = () => {
   const navigate = useNavigate();
   const createSkillParam = searchParams.get("createSkill") === "true";
   const [isModalOpen, setIsModalOpen] = useState(createSkillParam);
+  const [isAIModalOpen, setIsAIModalOpen] = useState(false);
+
+  const openAIGenerator = useCallback(() => setIsAIModalOpen(true), []);
 
   const { cursorMode, setCursorMode } = useCanvasStore();
   const { screenToFlowPosition } = useReactFlow();
@@ -38,6 +43,7 @@ export const Canvas = () => {
     setEdges,
     onEdgesChange,
     addQuestNode,
+    addQuestFromData,
     addSkillNode,
     collapseAll,
     expandAll,
@@ -59,6 +65,36 @@ export const Canvas = () => {
       setSearchParams({});
     },
     [addSkillNode, setSearchParams],
+  );
+
+  const handleAIGenerate = useCallback(
+    async (context: string) => {
+      const { skill, quests } = await generateSkillWithQuests(context);
+      addSkillNode({ x: 400, y: 50 }, skill);
+      const skillNodeId = useCanvasStore
+        .getState()
+        .nodes.find((n) => n.type === "skill")?.id;
+      quests.forEach((q, idx) => {
+        addQuestFromData(q);
+        if (idx === 0 && skillNodeId) {
+          onConnect({
+            source: skillNodeId,
+            target: q.questId,
+            sourceHandle: null,
+            targetHandle: null,
+          });
+        }
+        if (idx > 0) {
+          onConnect({
+            source: quests[idx - 1].questId,
+            target: q.questId,
+            sourceHandle: null,
+            targetHandle: null,
+          });
+        }
+      });
+    },
+    [addSkillNode, addQuestFromData, onConnect],
   );
 
   // - If no start point is selected, stores the clicked node's id.
@@ -101,6 +137,7 @@ export const Canvas = () => {
         setViewMode={setViewMode}
         collapseAll={collapseAll}
         expandAll={expandAll}
+        openAIGenerator={openAIGenerator}
       />
 
       <CreateSkillModal
@@ -111,6 +148,12 @@ export const Canvas = () => {
           setSearchParams({});
           navigate("/canvas");
         }}
+      />
+
+      <AIGenerateModal
+        open={isAIModalOpen}
+        onGenerate={handleAIGenerate}
+        onClose={() => setIsAIModalOpen(false)}
       />
 
       <Toaster position="bottom-right" />

--- a/src/modules/canvas/canvas.type.ts
+++ b/src/modules/canvas/canvas.type.ts
@@ -10,6 +10,7 @@ export type FloatingToolboxProps = {
   setViewMode: (mode: ViewModeType) => void;
   collapseAll: () => void;
   expandAll: () => void;
+  openAIGenerator: () => void;
 };
 
 export type SkillConfigType = {

--- a/src/modules/canvas/components/AIGenerateModal.tsx
+++ b/src/modules/canvas/components/AIGenerateModal.tsx
@@ -1,0 +1,48 @@
+import { ChevronLeft } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/shared/components/ui/button";
+import { Textarea } from "@/shared/components/ui/textarea";
+
+type AIGenerateModalProps = {
+  open: boolean;
+  onGenerate: (context: string) => void;
+  onClose: () => void;
+};
+
+export const AIGenerateModal = ({ open, onGenerate, onClose }: AIGenerateModalProps) => {
+  const [context, setContext] = useState("");
+  if (!open) return null;
+
+  const handleSubmit = () => {
+    if (!context.trim()) return;
+    onGenerate(context);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="backdrop-blur-md bg-white/10 border border-white/20 text-white p-6 rounded-2xl shadow-lg shadow-blue-500/20 w-full max-w-md relative">
+        <Button
+          variant="ghost"
+          onClick={onClose}
+          className="absolute top-3 left-3 cursor-pointer text-white hover:text-blue-300 bg-transparent hover:bg-transparent"
+        >
+          <ChevronLeft />
+        </Button>
+        <h2 className="text-2xl font-semibold mb-6 text-center">Génération automatique</h2>
+        <Textarea
+          placeholder="Décris le contexte"
+          value={context}
+          onChange={(e) => setContext(e.target.value)}
+          className="bg-white/10 border border-white/20 p-2 rounded w-full mb-3 text-white placeholder-white/70 focus:outline-none focus:ring-2 focus:ring-blue-400"
+        />
+        <Button
+          onClick={handleSubmit}
+          className="bg-blue-500 hover:bg-blue-600 text-white cursor-pointer px-4 py-2 mt-2 rounded-md w-full transition"
+        >
+          Générer
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/modules/canvas/components/CanvasView.tsx
+++ b/src/modules/canvas/components/CanvasView.tsx
@@ -33,6 +33,7 @@ type CanvasViewProps = {
   className?: string;
   collapseAll: () => void;
   expandAll: () => void;
+  openAIGenerator: () => void;
 };
 
 const nodeTypes = {
@@ -58,6 +59,7 @@ export const CanvasView = ({
   setViewMode,
   collapseAll,
   expandAll,
+  openAIGenerator,
 }: CanvasViewProps) => {
   const navigate = useNavigate();
 
@@ -128,6 +130,7 @@ export const CanvasView = ({
         setViewMode={setViewMode}
         collapseAll={collapseAll}
         expandAll={expandAll}
+        openAIGenerator={openAIGenerator}
       />
 
       {/* Mode Indicators */}

--- a/src/modules/canvas/components/floating-toolbox/FloatingToolbox.tsx
+++ b/src/modules/canvas/components/floating-toolbox/FloatingToolbox.tsx
@@ -10,6 +10,7 @@ export const FloatingToolbox = ({
   // setViewMode,
   collapseAll,
   expandAll,
+  openAIGenerator,
 }: FloatingToolboxProps) => {
   const [areNodesCollapsed, setAreNodesCollapsed] = useState<boolean>(false);
 
@@ -61,6 +62,7 @@ export const FloatingToolbox = ({
           setCursorMode={setCursorMode}
           colllapseAll={collapseAll}
           expandAll={expandAll}
+          openAIGenerator={openAIGenerator}
         />
       ))}
     </div>

--- a/src/modules/canvas/components/floating-toolbox/ToolButton.tsx
+++ b/src/modules/canvas/components/floating-toolbox/ToolButton.tsx
@@ -8,9 +8,10 @@ type ToolButtonProps = {
   setCursorMode: (mode: CursorModeType) => void;
   colllapseAll?: () => void;
   expandAll?: () => void;
+  openAIGenerator?: () => void;
 };
 
-export const ToolButton = ({ tool, cursorMode, setCursorMode, colllapseAll, expandAll }: ToolButtonProps) => {
+export const ToolButton = ({ tool, cursorMode, setCursorMode, colllapseAll, expandAll, openAIGenerator }: ToolButtonProps) => {
   const active = tool.isActive(cursorMode);
 
   return (
@@ -21,6 +22,7 @@ export const ToolButton = ({ tool, cursorMode, setCursorMode, colllapseAll, expa
           tool.handleToolClick(setCursorMode, cursorMode, {
             collapseAll: colllapseAll,
             expandAll: expandAll,
+            openAIGenerator: openAIGenerator,
           })
         }
         size="sm"

--- a/src/modules/canvas/components/floating-toolbox/toolbox.const.tsx
+++ b/src/modules/canvas/components/floating-toolbox/toolbox.const.tsx
@@ -1,4 +1,4 @@
-import { Link, Plus, Target } from "lucide-react";
+import { Link, Plus, Target, Sparkles } from "lucide-react";
 import type { CursorModeType, ViewModeType } from "../../canvas.type";
 
 export type ToolBoxItem = {
@@ -14,6 +14,7 @@ export type ToolBoxItem = {
       collapseAll?: () => void;
       expandAll?: () => void;
       setViewMode?: (mode: ViewModeType) => void;
+      openAIGenerator?: () => void;
     },
   ) => void;
 };
@@ -44,6 +45,16 @@ export const tools: ToolboxList = [
     activeColor: "bg-gray-600 hover:bg-gray-700 text-white",
     isActive: (mode) => mode === "normal",
     handleToolClick: (setCursorMode) => setCursorMode("normal"),
+  },
+  {
+    id: "ai-generate",
+    icon: <Sparkles className="w-5 h-5 text-white group-hover:text-black transition-colors" />,
+    tooltip: "AI Generate",
+    activeColor: "bg-green-600 hover:bg-green-700 text-white",
+    isActive: () => false,
+    handleToolClick: (_, __, ctx) => {
+      ctx?.openAIGenerator?.();
+    },
   },
   // {
   //   id: "roadmap",

--- a/src/modules/canvas/hooks/useCanvasGraph.ts
+++ b/src/modules/canvas/hooks/useCanvasGraph.ts
@@ -10,6 +10,7 @@ import type { QuestNodeData, SkillNodeData } from "../canvas.type";
 import { useCanvasStore } from "@/stores/quest/canvas-store";
 import { useCallback } from "react";
 import type { Skill } from "@/shared/types/skill.type";
+import type { Quest } from "@/shared/types/quest.type";
 import { isQuestNode } from "../canvas.const";
 // import { isQuestNode } from "../canvas.const";
 
@@ -81,6 +82,29 @@ export const useCanvasGraph = () => {
     markNew(id);
   };
 
+  const addQuestFromData = (quest: Quest) => {
+    const id = quest.questId || `quest-${crypto.randomUUID()}`;
+    const newNode: Node<QuestNodeData> = {
+      id,
+      type: "questNode",
+      position: quest.position,
+      data: {
+        kind: "quest",
+        title: quest.title,
+        xp: quest.xp,
+        difficulty: quest.difficulty,
+        description: quest.description,
+        status: quest.status,
+        isCollapsed: false,
+        isSubSkill: quest.isSubSkill,
+        onDelete: (nid: string) => removeNode(nid),
+        onUpdate: (field: string, value: any) => updateNodeData(id, field, value),
+      },
+    };
+    addNode(newNode);
+    markNew(id);
+  };
+
   const addSkillNode = (position: XYPosition, skill: Skill) => {
     const id = `skill-${crypto.randomUUID()}`;
     const newNode: Node<SkillNodeData> = {
@@ -133,6 +157,7 @@ export const useCanvasGraph = () => {
     setEdges,
     onEdgesChange,
     addQuestNode,
+    addQuestFromData,
     addSkillNode,
     deleteNode: removeNode,
     collapseAll,

--- a/src/shared/services/google-genai.service.ts
+++ b/src/shared/services/google-genai.service.ts
@@ -1,0 +1,25 @@
+import { GoogleGenerativeAI } from "@google/genai";
+import type { Skill } from "@/shared/types/skill.type";
+import type { Quest } from "@/shared/types/quest.type";
+
+export type GenerateSkillWithQuestsResult = {
+  skill: Skill;
+  quests: Quest[];
+};
+
+const apiKey = import.meta.env.VITE_GOOGLE_GENAI_API_KEY;
+
+const genAI = new GoogleGenerativeAI(apiKey);
+
+export const generateSkillWithQuests = async (
+  context: string,
+): Promise<GenerateSkillWithQuestsResult> => {
+  const model = genAI.getGenerativeModel({ model: "gemini-pro" });
+
+  const prompt = `Genere un skill avec des quetes en suivant ce contexte:\n${context}\n` +
+    `Reponds uniquement avec un JSON contenant un objet { skill: Skill, quests: Quest[] }`;
+
+  const result = await model.generateContent(prompt);
+  const text = result.response.text();
+  return JSON.parse(text) as GenerateSkillWithQuestsResult;
+};

--- a/src/types/google__genai.d.ts
+++ b/src/types/google__genai.d.ts
@@ -1,0 +1,8 @@
+declare module "@google/genai" {
+  export class GoogleGenerativeAI {
+    constructor(apiKey: string);
+    getGenerativeModel(options: { model: string }): {
+      generateContent(prompt: string): Promise<{ response: { text(): string } }>;
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add AI generation modal and floating toolbox button
- connect new tool with Google GenAI service
- wire up quest generation on the canvas

## Testing
- `npm install` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876ce2f98348320a17b7fea0ab4b865