### PR TITLE
Add manual quest context store and integrate with generator

### DIFF
--- a/src/modules/canvas/components/AIQuestGenerationModal.tsx
+++ b/src/modules/canvas/components/AIQuestGenerationModal.tsx
@@ -14,25 +14,34 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { Checkbox } from "@/shared/components/ui/checkbox";
+import { Textarea } from "@/shared/components/ui/textarea";
 import { useState } from "react";
+import { useQuestGenerationFormStore } from "@/stores/quest-generation-form-store";
 import { ChevronDown, ChevronUp, Sparkles, Target, Settings, Trophy, BookOpen } from "lucide-react";
 import "../../../styles/ai-quest-generation-modal.css";
 
 // Schéma Zod pour la validation du formulaire
-const questContextSchema = z.object({
-  goal: z.string().min(1, "Requis"),
-  description: z.string().optional(),
-  selfLevel: z.enum(["1", "2", "3", "4", "5"]).optional(),
-  weeklyTime: z.string().optional(),
-  autoEstimate: z.boolean().optional(),
-  // Champs avancés
-  numberOfQuests: z.number().min(1).optional(),
-  avgQuestDuration: z.string().optional(),
-  modality: z.enum(["Théorique", "Equilibré", "Pratique"]).optional(),
-  themeStyle: z.enum(["Médiéval", "High-tech", "Space Opera", "Détective"]).optional(),
-  toolsConstraint: z.string().optional(),
-  rewardPreference: z.string().optional(),
-});
+const questContextSchema = z
+  .object({
+    manualContext: z.boolean().optional(),
+    contextText: z.string().optional(),
+    goal: z.string().optional(),
+    description: z.string().optional(),
+    selfLevel: z.enum(["1", "2", "3", "4", "5"]).optional(),
+    weeklyTime: z.string().optional(),
+    autoEstimate: z.boolean().optional(),
+    // Champs avancés
+    numberOfQuests: z.number().min(1).optional(),
+    avgQuestDuration: z.string().optional(),
+    modality: z.enum(["Théorique", "Equilibré", "Pratique"]).optional(),
+    themeStyle: z.enum(["Médiéval", "High-tech", "Space Opera", "Détective"]).optional(),
+    toolsConstraint: z.string().optional(),
+    rewardPreference: z.string().optional(),
+  })
+  .refine((data) => data.manualContext || !!data.goal, {
+    message: "Requis",
+    path: ["goal"],
+  });
 
 type QuestContextForm = z.infer<typeof questContextSchema>;
 
@@ -64,20 +73,28 @@ const userLevel = [
   },
 ];
 
-export const AIQuestGenerationModal = () => {
+type AIQuestGenerationModalProps = {
+  onGenerate: () => void;
+  onClose: () => void;
+};
+
+export const AIQuestGenerationModal = ({ onGenerate, onClose }: AIQuestGenerationModalProps) => {
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
   const form = useForm<QuestContextForm>({
     resolver: zodResolver(questContextSchema),
-    defaultValues: { autoEstimate: true },
+    defaultValues: { autoEstimate: true, manualContext: false },
   });
 
+  const setForm = useQuestGenerationFormStore((s) => s.setForm);
+
   const submit = (data: QuestContextForm) => {
-    // Logic to send context to IA generation
-    console.log("AI Context:", data);
+    setForm(data);
+    onGenerate();
+    onClose();
   };
 
   const handleClose = () => {
-    // Logic to close modal
+    onClose();
   };
 
   return (
@@ -102,100 +119,147 @@ export const AIQuestGenerationModal = () => {
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(submit)} className="space-y-6">
-            {/* Section Objectif Principal */}
+            {/* Choix du mode de remplissage */}
             <div className="form-section">
-              <div className="flex items-center gap-3 mb-4">
-                <div className="p-2 bg-blue-900/50 rounded-lg">
-                  <Target className="h-5 w-5 text-blue-400" />
-                </div>
-                <div>
-                  <h3 className="font-semibold text-lg text-gray-100">Objectif final ou le projet concret visé</h3>
-                  <p className="text-sm text-gray-400">Indique le but que tu veux atteindre</p>
-                </div>
-              </div>
-
               <FormField
                 control={form.control}
-                name="goal"
+                name="manualContext"
                 render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-sm font-medium text-gray-200">
-                      Objectif <span className="text-red-400">*</span>
-                    </FormLabel>
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0">
                     <FormControl>
-                      <Input
-                        {...field}
-                        placeholder="Ex. Maîtriser Git et GitHub pour la collaboration"
-                        className="h-12 text-base  border-gray-600 text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500"
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        className="data-[state=checked]:bg-blue-600 data-[state=checked]:border-blue-600"
                       />
                     </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="description"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="mt-3 text-sm font-medium text-gray-200">Description (recommandé)</FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        placeholder="Une phrase décrivant plus en détail ton but final"
-                        className="h-12 text-base border-gray-600 text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500"
-                      />
-                    </FormControl>
-                    <FormMessage />
+                    <div className="space-y-1">
+                      <FormLabel className="font-medium text-gray-100">Écrire mon contexte manuellement</FormLabel>
+                      <p className="text-sm text-gray-400">Rédige toi-même l'ensemble du contexte</p>
+                    </div>
                   </FormItem>
                 )}
               />
             </div>
 
-            {/* Section Profil */}
-            <div className="form-section">
-              <div className="flex items-center gap-3 mb-4">
-                <div className="p-2 bg-green-900/50 rounded-lg">
-                  <BookOpen className="h-5 w-5 text-green-400" />
-                </div>
-                <div>
-                  <h3 className="font-semibold text-lg text-gray-100">Ton Profil</h3>
-                  <p className="text-sm text-gray-400">Aide l'IA à personnaliser ton parcours</p>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {form.watch("manualContext") ? (
+              <div className="form-section">
                 <FormField
                   control={form.control}
-                  name="selfLevel"
+                  name="contextText"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel className="text-sm font-medium text-gray-200">Niveau actuel</FormLabel>
+                      <FormLabel className="text-sm font-medium text-gray-200">Contexte</FormLabel>
                       <FormControl>
-                        <Select onValueChange={field.onChange} value={field.value}>
-                          <SelectTrigger className="h-12  border-gray-600 text-gray-100 focus:border-blue-500 focus:ring-blue-500">
-                            <SelectValue placeholder="Sélectionne ton niveau" />
-                          </SelectTrigger>
-                          <SelectContent className="border-gray-600 bg-[#182131]">
-                            {userLevel.map((lvl) => (
-                              <SelectItem
-                                key={lvl.value}
-                                value={lvl.value}
-                                className="text-gray-100 hover:bg-gray-700 flex items-center gap-2"
-                              >
-                                <span>{lvl.label}</span>
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                        <Textarea
+                          {...field}
+                          placeholder="Décris ici tout ton contexte, objectifs et contraintes"
+                          className="h-40 text-base border-gray-600 text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500"
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
+              </div>
+            ) : (
+              <>
+                {/* Section Objectif Principal */}
+                <div className="form-section">
+                  <div className="flex items-center gap-3 mb-4">
+                    <div className="p-2 bg-blue-900/50 rounded-lg">
+                      <Target className="h-5 w-5 text-blue-400" />
+                    </div>
+                    <div>
+                      <h3 className="font-semibold text-lg text-gray-100">Objectif final ou le projet concret visé</h3>
+                      <p className="text-sm text-gray-400">Indique le but que tu veux atteindre</p>
+                    </div>
+                  </div>
 
-                {/* <FormField
+                  <FormField
+                    control={form.control}
+                    name="goal"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-sm font-medium text-gray-200">
+                          Objectif <span className="text-red-400">*</span>
+                        </FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder="Ex. Maîtriser Git et GitHub pour la collaboration"
+                            className="h-12 text-base  border-gray-600 text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="description"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="mt-3 text-sm font-medium text-gray-200">
+                          Description (recommandé)
+                        </FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder="Une phrase décrivant plus en détail ton but final"
+                            className="h-12 text-base border-gray-600 text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                {/* Section Profil */}
+                <div className="form-section">
+                  <div className="flex items-center gap-3 mb-4">
+                    <div className="p-2 bg-green-900/50 rounded-lg">
+                      <BookOpen className="h-5 w-5 text-green-400" />
+                    </div>
+                    <div>
+                      <h3 className="font-semibold text-lg text-gray-100">Ton Profil</h3>
+                      <p className="text-sm text-gray-400">Aide l'IA à personnaliser ton parcours</p>
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <FormField
+                      control={form.control}
+                      name="selfLevel"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-sm font-medium text-gray-200">Niveau actuel</FormLabel>
+                          <FormControl>
+                            <Select onValueChange={field.onChange} value={field.value}>
+                              <SelectTrigger className="h-12 w-full border-gray-600 text-gray-100 focus:border-blue-500 focus:ring-blue-500">
+                                <SelectValue placeholder="Sélectionne ton niveau" />
+                              </SelectTrigger>
+                              <SelectContent className="border-gray-600 bg-[#182131]">
+                                {userLevel.map((lvl) => (
+                                  <SelectItem
+                                    key={lvl.value}
+                                    value={lvl.value}
+                                    className="text-gray-100 hover:bg-gray-700 flex items-center gap-2"
+                                  >
+                                    <span>{lvl.label}</span>
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    {/* <FormField
                   control={form.control}
                   name="weeklyTime"
                   render={({ field }) => (
@@ -213,222 +277,213 @@ export const AIQuestGenerationModal = () => {
                   )}
                 /> */}
 
-                <FormField
-                  control={form.control}
-                  name="weeklyTime"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-sm font-medium text-gray-200">Compétence connexe</FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          placeholder="Ex. Je maitrise le JS, le CSS, le HTML etc..."
-                          className="h-12 text-base  border-gray-600 text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </div>
-
-            {/* Section Configuration */}
-            <div className="form-section">
-              <div className="flex items-center gap-3 mb-4">
-                <div className="p-2 bg-purple-900/50 rounded-lg">
-                  <Settings className="h-5 w-5 text-purple-400" />
+                    <FormField
+                      control={form.control}
+                      name="weeklyTime"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-sm font-medium text-gray-200">Compétence connexe</FormLabel>
+                          <FormControl>
+                            <Input
+                              {...field}
+                              placeholder="Ex. Je maitrise le JS, le CSS, le HTML etc..."
+                              className="h-12 text-base  border-gray-600 text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
                 </div>
-                <div>
-                  <h3 className="font-semibold text-lg text-gray-100">Configuration</h3>
-                  <p className="text-sm text-gray-400">Personnalise la génération</p>
-                </div>
-              </div>
 
-              <FormField
-                control={form.control}
-                name="autoEstimate"
-                render={({ field }) => (
-                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 p-4 /50 rounded-lg border border-gray-600">
-                    <FormControl>
-                      <Checkbox
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                        className="data-[state=checked]:bg-blue-600 data-[state=checked]:border-blue-600"
-                      />
-                    </FormControl>
-                    <div className="space-y-1">
-                      <FormLabel className="font-medium text-gray-100">Estimation automatique</FormLabel>
-                      <p className="text-sm text-gray-400">Laisse l'IA estimer la durée et le nombre de quêtes</p>
+                {/* Section Configuration */}
+                <div className="form-section">
+                  <div className="flex items-center gap-3 mb-4">
+                    <div className="p-2 bg-purple-900/50 rounded-lg">
+                      <Settings className="h-5 w-5 text-purple-400" />
                     </div>
-                  </FormItem>
-                )}
-              />
+                    <div>
+                      <h3 className="font-semibold text-lg text-gray-100">Configuration</h3>
+                      <p className="text-sm text-gray-400">Personnalise la génération</p>
+                    </div>
+                  </div>
 
-              {/* Section Avancée */}
-              {!form.watch("autoEstimate") && (
-                <div className="bg-gradient-to-br from-gray-900 to-gray-800 mt-4 rounded-lg overflow-hidden shadow-[0_2px_8px_rgba(0,0,0,0.3)]">
+                  <FormField
+                    control={form.control}
+                    name="autoEstimate"
+                    render={({ field }) => (
+                      <FormItem className="flex flex-row items-start space-x-3 space-y-0 p-4 /50 rounded-lg border border-gray-600">
+                        <FormControl>
+                          <Checkbox
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                            className="data-[state=checked]:bg-blue-600 data-[state=checked]:border-blue-600"
+                          />
+                        </FormControl>
+                        <div className="space-y-1">
+                          <FormLabel className="font-medium text-gray-100">Estimation automatique</FormLabel>
+                          <p className="text-sm text-gray-400">Laisse l'IA estimer la durée et le nombre de quêtes</p>
+                        </div>
+                      </FormItem>
+                    )}
+                  />
+
+                  {/* Section Avancée */}
+                  {!form.watch("autoEstimate") && (
+                    <div className="bg-gradient-to-br from-gray-900 to-gray-800 mt-4 rounded-lg overflow-hidden shadow-[0_2px_8px_rgba(0,0,0,0.3)]">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => setIsAdvancedOpen(!isAdvancedOpen)}
+                        className="w-full flex items-center justify-between p-4 bg-gradient-to-r from-gray-800 to-gray-700 hover:from-gray-700 hover:to-gray-600 transition-all duration-200"
+                      >
+                        <div className="flex items-center gap-3">
+                          <div className="p-2 bg-orange-900/50 rounded-lg">
+                            <Trophy className="h-4 w-4 text-orange-400" />
+                          </div>
+                          <span className="font-medium text-gray-100">Options avancées</span>
+                        </div>
+                        {isAdvancedOpen ? (
+                          <ChevronUp className="h-5 w-5 text-gray-400" />
+                        ) : (
+                          <ChevronDown className="h-5 w-5 text-gray-400" />
+                        )}
+                      </Button>
+
+                      {isAdvancedOpen && (
+                        <div className="mt-2 p-2 space-y-4 animate-in slide-in-from-top-2 duration-200">
+                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <FormField
+                              control={form.control}
+                              name="numberOfQuests"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel className="text-sm font-medium text-gray-200">Nombre de quêtes</FormLabel>
+                                  <FormControl>
+                                    <Input
+                                      type="number"
+                                      {...field}
+                                      placeholder="Ex. 5"
+                                      className="h-12 w-full text-base  border-gray-600 text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500"
+                                    />
+                                  </FormControl>
+                                  {/* <FormMessage /> */}
+                                </FormItem>
+                              )}
+                            />
+
+                            <FormField
+                              control={form.control}
+                              name="modality"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel className="text-sm font-medium text-gray-200">
+                                    Style d'apprentissage
+                                  </FormLabel>
+                                  <FormControl>
+                                    <Select onValueChange={field.onChange} value={field.value}>
+                                      <SelectTrigger className="h-12 w-full border-gray-600 text-gray-100 focus:border-blue-500 focus:ring-blue-500">
+                                        <SelectValue placeholder="Choisis un style" />
+                                      </SelectTrigger>
+                                      <SelectContent className=" border-gray-600 bg-[#182131]">
+                                        {["Théorique", "Equilibré", "Pratique"].map((opt) => (
+                                          <SelectItem key={opt} value={opt} className="text-gray-100 hover:bg-gray-700">
+                                            {opt}
+                                          </SelectItem>
+                                        ))}
+                                      </SelectContent>
+                                    </Select>
+                                  </FormControl>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          </div>
+
+                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <FormField
+                              control={form.control}
+                              name="themeStyle"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel className="text-sm font-medium text-gray-200">Ambiance</FormLabel>
+                                  <FormControl>
+                                    <Select onValueChange={field.onChange} value={field.value}>
+                                      <SelectTrigger className="h-12 w-full border-gray-600 text-gray-100 focus:border-blue-500 focus:ring-blue-500">
+                                        <SelectValue placeholder="Ex. Médiéval" />
+                                      </SelectTrigger>
+                                      <SelectContent className=" border-gray-600 bg-[#182131]">
+                                        {["Médiéval", "High-tech", "Space Opera", "Détective"].map((opt) => (
+                                          <SelectItem key={opt} value={opt} className="text-gray-100 hover:bg-gray-700">
+                                            {opt}
+                                          </SelectItem>
+                                        ))}
+                                      </SelectContent>
+                                    </Select>
+                                  </FormControl>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+
+                            <FormField
+                              control={form.control}
+                              name="toolsConstraint"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel className="text-sm font-medium text-gray-200">
+                                    Type de ressources
+                                  </FormLabel>
+                                  <FormControl>
+                                    <Select onValueChange={field.onChange} value={field.value}>
+                                      <SelectTrigger className="h-12 w-full border-gray-600 text-gray-100 focus:border-blue-500 focus:ring-blue-500">
+                                        <SelectValue placeholder="ressource" />
+                                      </SelectTrigger>
+                                      <SelectContent className=" border-gray-600 bg-[#182131]">
+                                        {[
+                                          "Vidés",
+                                          "Article de bloc",
+                                          "Documentation",
+                                          "Exercices intéractifs, Livres",
+                                        ].map((opt) => (
+                                          <SelectItem key={opt} value={opt} className="text-gray-100 hover:bg-gray-700">
+                                            {opt}
+                                          </SelectItem>
+                                        ))}
+                                      </SelectContent>
+                                    </Select>
+                                  </FormControl>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <DialogFooter className="flex flex-col sm:flex-row gap-3 pt-6 border-t border-gray-600">
                   <Button
                     type="button"
-                    variant="ghost"
-                    onClick={() => setIsAdvancedOpen(!isAdvancedOpen)}
-                    className="w-full flex items-center justify-between p-4 bg-gradient-to-r from-gray-800 to-gray-700 hover:from-gray-700 hover:to-gray-600 transition-all duration-200"
+                    variant="default"
+                    onClick={handleClose}
+                    className="w-full sm:w-auto bg-gradient-to-br from-red-700 via-red-900 to-gray-800 h-12 cursor-pointer px-6 border-gray-600 text-gray-300 hover:bg-red-800 hover:text-gray-100"
                   >
-                    <div className="flex items-center gap-3">
-                      <div className="p-2 bg-orange-900/50 rounded-lg">
-                        <Trophy className="h-4 w-4 text-orange-400" />
-                      </div>
-                      <span className="font-medium text-gray-100">Options avancées</span>
-                    </div>
-                    {isAdvancedOpen ? (
-                      <ChevronUp className="h-5 w-5 text-gray-400" />
-                    ) : (
-                      <ChevronDown className="h-5 w-5 text-gray-400" />
-                    )}
+                    Annuler
                   </Button>
-
-                  {isAdvancedOpen && (
-                    <div className="mt-2 p-2 space-y-4 animate-in slide-in-from-top-2 duration-200">
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <FormField
-                          control={form.control}
-                          name="numberOfQuests"
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel className="text-sm font-medium text-gray-200">Nombre de quêtes</FormLabel>
-                              <FormControl>
-                                <Input
-                                  type="number"
-                                  {...field}
-                                  placeholder="Ex. 5"
-                                  className="h-12 text-base  border-gray-600 text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500"
-                                />
-                              </FormControl>
-                              {/* <FormMessage /> */}
-                            </FormItem>
-                          )}
-                        />
-
-                        <FormField
-                          control={form.control}
-                          name="modality"
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel className="text-sm font-medium text-gray-200">Style d'apprentissage</FormLabel>
-                              <FormControl>
-                                <Select onValueChange={field.onChange} value={field.value}>
-                                  <SelectTrigger className="h-12  border-gray-600 text-gray-100 focus:border-blue-500 focus:ring-blue-500">
-                                    <SelectValue placeholder="Choisis un style" />
-                                  </SelectTrigger>
-                                  <SelectContent className=" border-gray-600 bg-[#182131]">
-                                    {["Théorique", "Equilibré", "Pratique"].map((opt) => (
-                                      <SelectItem key={opt} value={opt} className="text-gray-100 hover:bg-gray-700">
-                                        {opt}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      </div>
-
-                      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                        <FormField
-                          control={form.control}
-                          name="themeStyle"
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel className="text-sm font-medium text-gray-200">Ambiance</FormLabel>
-                              <FormControl>
-                                <Select onValueChange={field.onChange} value={field.value}>
-                                  <SelectTrigger className="h-12  border-gray-600 text-gray-100 focus:border-blue-500 focus:ring-blue-500">
-                                    <SelectValue placeholder="Ex. Médiéval" />
-                                  </SelectTrigger>
-                                  <SelectContent className=" border-gray-600 bg-[#182131]">
-                                    {["Médiéval", "High-tech", "Space Opera", "Détective"].map((opt) => (
-                                      <SelectItem key={opt} value={opt} className="text-gray-100 hover:bg-gray-700">
-                                        {opt}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-
-                        <FormField
-                          control={form.control}
-                          name="themeStyle"
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel className="text-sm font-medium text-gray-200">Type de ressources</FormLabel>
-                              <FormControl>
-                                <Select onValueChange={field.onChange} value={field.value}>
-                                  <SelectTrigger className="h-12  border-gray-600 text-gray-100 focus:border-blue-500 focus:ring-blue-500">
-                                    <SelectValue placeholder="ressource" />
-                                  </SelectTrigger>
-                                  <SelectContent className=" border-gray-600 bg-[#182131]">
-                                    {["Vidés", "Article de bloc", "Documentation", "Exercices intéractifs, Livres"].map(
-                                      (opt) => (
-                                        <SelectItem key={opt} value={opt} className="text-gray-100 hover:bg-gray-700">
-                                          {opt}
-                                        </SelectItem>
-                                      ),
-                                    )}
-                                  </SelectContent>
-                                </Select>
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      </div>
-
-                      <FormField
-                        control={form.control}
-                        name="toolsConstraint"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel className="text-sm font-medium text-gray-200">Contexte</FormLabel>
-                            <FormControl>
-                              <Input
-                                {...field}
-                                placeholder="Ex. VSCode, Internet limité, etc."
-                                className="h-12 text-base  border-gray-600 text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500"
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-
-            <DialogFooter className="flex flex-col sm:flex-row gap-3 pt-6 border-t border-gray-600">
-              <Button
-                type="button"
-                variant="default"
-                onClick={handleClose}
-                className="w-full sm:w-auto bg-gradient-to-br from-red-700 via-red-900 to-gray-800 h-12 cursor-pointer px-6 border-gray-600 text-gray-300 hover:bg-red-800 hover:text-gray-100"
-              >
-                Annuler
-              </Button>
-              <Button
-                type="submit"
-                className="w-full sm:w-auto h-12 px-8 bg-gradient-to-r from-blue-600 to-purple-600 cursor-pointer hover:from-blue-700 hover:to-purple-700 text-white font-medium shadow-lg hover:shadow-xl transition-all duration-200"
-              >
-                <Sparkles className="h-4 w-4 mr-2" />
-                Générer mes quêtes
-              </Button>
-            </DialogFooter>
+                  <Button
+                    type="submit"
+                    className="w-full sm:w-auto h-12 px-8 bg-gradient-to-r from-blue-600 to-purple-600 cursor-pointer hover:from-blue-700 hover:to-purple-700 text-white font-medium shadow-lg hover:shadow-xl transition-all duration-200"
+                  >
+                    <Sparkles className="h-4 w-4 mr-2" />
+                    Générer mes quêtes
+                  </Button>
+                </DialogFooter>
+              </>
+            )}
           </form>
         </Form>
       </DialogContent>

--- a/src/modules/canvas/components/CanvasView.tsx
+++ b/src/modules/canvas/components/CanvasView.tsx
@@ -144,7 +144,7 @@ export const CanvasView = ({
         setOpenAiModal={setOpenAiModal}
       />
 
-      {ôpenAiModal && <AIQuestGenerationModal />}
+      {ôpenAiModal && <AIQuestGenerationModal onGenerate={openAIGenerator} onClose={() => setOpenAiModal(false)} />}
 
       {/* Mode Indicators */}
       {cursorMode === "create" && (

--- a/src/modules/canvas/hooks/ai/useGeminiContext.ts
+++ b/src/modules/canvas/hooks/ai/useGeminiContext.ts
@@ -1,9 +1,11 @@
 import { useCanvasStore } from "@/stores/canvas/canvas-store";
 import { isQuestNode, isSkillNode } from "../../canvas.const";
 import type { GeminiContext, QuestAiType, SkillAiType } from "@/shared/types/ai/ai.type";
+import { useQuestGenerationFormStore } from "@/stores/quest-generation-form-store";
 
 export const useGeminiContext = (): GeminiContext => {
   const nodes = useCanvasStore((s) => s.nodes);
+  const form = useQuestGenerationFormStore((s) => s.form);
   const skillNode = nodes.find(isSkillNode);
 
   const existingQuests: QuestAiType[] = nodes.filter(isQuestNode).map((node) => ({
@@ -16,18 +18,35 @@ export const useGeminiContext = (): GeminiContext => {
 
   const skillForAi: SkillAiType = {
     ...skillNode?.data.config,
-    level: "Débutant",
-    goal: "Atteindre la maîtrise de ce skill via un projet concret",
+    level: form.selfLevel ?? "Débutant",
+    goal: form.goal ?? "Atteindre la maîtrise de ce skill via un projet concret",
+    description: form.description ?? skillNode?.data.config.description,
   };
 
+  let instruction =
+    "Génère 3 quêtes originales, progressives (de facile à difficile), " +
+    "en respectant l'objectif final et sans doublons avec les quêtes existantes." +
+    " Chaque quête doit être unique et apporter une valeur ajoutée à l'apprentissage du skill." +
+    "\n\nCritères de qualité :" +
+    "\n- Chaque quête doit avoir un objectif concret et mesurable" +
+    "\n- Les quêtes doivent former une progression logique (bases → intermédiaire → avancé)" +
+    "\n- Inclure des éléments pratiques et applicables dans le monde réel" +
+    "\n- Éviter les quêtes trop théoriques ou abstraites" +
+    "\n- S'assurer que chaque quête développe des compétences spécifiques et identifiables" +
+    "\n- Proposer des défis stimulants mais réalisables pour le niveau indiqué";
+
+  if (form.manualContext && form.contextText) {
+    instruction = form.contextText;
+  } else {
+    if (form.modality) instruction += `\nStyle d'apprentissage : ${form.modality}`;
+    if (form.themeStyle) instruction += `\nAmbiance : ${form.themeStyle}`;
+    if (form.toolsConstraint) instruction += `\nType de ressources : ${form.toolsConstraint}`;
+    if (form.numberOfQuests) instruction += `\nNombre de quêtes souhaité : ${form.numberOfQuests}`;
+    if (form.weeklyTime) instruction += `\nCompétences connexes : ${form.weeklyTime}`;
+  }
+
   return {
-    skill: skillForAi && {
-      title: skillForAi.title,
-      description: skillForAi.description,
-      difficulty: skillForAi.difficulty,
-      level: skillForAi.level ?? "Débutant",
-      goal: skillForAi.goal ?? "Atteindre la maîtrise de ce skill via un projet concret",
-    },
+    skill: skillForAi,
     existingQuests,
     format: {
       title: "string",
@@ -36,16 +55,6 @@ export const useGeminiContext = (): GeminiContext => {
       difficulty: "EASY|MEDIUM|HARD",
       prerequisites: "string[] (optional)",
     },
-    instruction:
-      "Génère 3 quêtes originales, progressives (de facile à difficile), " +
-      "en respectant l'objectif final et sans doublons avec les quêtes existantes." +
-      " Chaque quête doit être unique et apporter une valeur ajoutée à l'apprentissage du skill." +
-      "\n\nCritères de qualité :" +
-      "\n- Chaque quête doit avoir un objectif concret et mesurable" +
-      "\n- Les quêtes doivent former une progression logique (bases → intermédiaire → avancé)" +
-      "\n- Inclure des éléments pratiques et applicables dans le monde réel" +
-      "\n- Éviter les quêtes trop théoriques ou abstraites" +
-      "\n- S'assurer que chaque quête développe des compétences spécifiques et identifiables" +
-      "\n- Proposer des défis stimulants mais réalisables pour le niveau indiqué",
+    instruction,
   };
 };

--- a/src/stores/quest-generation-form-store.ts
+++ b/src/stores/quest-generation-form-store.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+export type QuestGenerationForm = {
+  manualContext?: boolean;
+  contextText?: string;
+  goal?: string;
+  description?: string;
+  selfLevel?: string;
+  weeklyTime?: string;
+  autoEstimate?: boolean;
+  numberOfQuests?: number;
+  modality?: "Théorique" | "Equilibré" | "Pratique";
+  themeStyle?: string;
+  toolsConstraint?: string;
+  rewardPreference?: string;
+};
+
+type QuestGenerationFormStore = {
+  form: Partial<QuestGenerationForm>;
+  setForm: (data: Partial<QuestGenerationForm>) => void;
+  reset: () => void;
+};
+
+export const useQuestGenerationFormStore = create<QuestGenerationFormStore>((set) => ({
+  form: {},
+  setForm: (data) => set((state) => ({ form: { ...state.form, ...data } })),
+  reset: () => set({ form: {} }),
+}));


### PR DESCRIPTION
## Summary
- store quest generation form values in Zustand
- pass callbacks to AIQuestGenerationModal
- update modal layout and fields
- merge form data into Gemini context

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6888908ea4108320b75c580f4ce042d6