### PR TITLE
feat: add HeyGen avatar for voice quest generation

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -3,6 +3,9 @@ interface ImportMetaEnv {
   readonly VITE_GOOGLE_GENAI_API_KEY: string;
   readonly VITE_OPENAI_HUGGINGFACE_API_KEY: string;
   readonly VITE_OPENAI_HUGGINGFACE_BASE_URL: string;
+  readonly VITE_HEYGEN_TOKEN: string;
+  readonly VITE_HEYGEN_AVATAR: string;
+  readonly VITE_HEYGEN_VOICE: string;
 }
 
 interface ImportMeta {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fullcalendar/react": "^6.1.18",
         "@fullcalendar/timegrid": "^6.1.18",
         "@google/genai": "^1.10.0",
+        "@heygen/streaming-avatar": "^2.0.16",
         "@hookform/resolvers": "^5.2.0",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -377,6 +378,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@commitlint/cli": {
       "version": "19.8.1",
@@ -1338,6 +1345,17 @@
         }
       }
     },
+    "node_modules/@heygen/streaming-avatar": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@heygen/streaming-avatar/-/streaming-avatar-2.0.16.tgz",
+      "integrity": "sha512-KIQbHEs8JPQlaGauIPvz+gpwtPvMUzGRgg6xwVMhwsDmADQCga+CNor79jDDOFZANdOIp/LYMpAOCYtketFoww==",
+      "license": "MIT",
+      "dependencies": {
+        "livekit-client": "^2.11.3",
+        "protobufjs": "^7.5.0",
+        "webrtc-issue-detector": "^1.16.3"
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
@@ -1473,6 +1491,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.39.3",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.39.3.tgz",
+      "integrity": "sha512-hfOnbwPCeZBEvMRdRhU2sr46mjGXavQcrb3BFRfG+Gm0Z7WUSeFdy5WLstXJzEepz17Iwp/lkGwJ4ZgOOYfPuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1510,6 +1543,70 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -2831,6 +2928,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2881,7 +2985,6 @@
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
       "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
@@ -4445,6 +4548,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5494,6 +5606,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/livekit-client": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.15.5.tgz",
+      "integrity": "sha512-zn36akmDlqZxlrTOUgYXtxtj35HQ44aJ+mgKat9BTSPiZru4RjEHOtp8RJE6jGoN2miJlWiOeEKHB2+ae3YrSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.39.3",
+        "events": "^3.3.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "ts-debounce": "^4.0.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
@@ -5572,6 +5704,25 @@
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -6611,6 +6762,30 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6960,6 +7135,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6985,6 +7170,21 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
+    },
+    "node_modules/sdp": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
+      "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -7328,6 +7528,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
+      "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -7355,6 +7561,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
       }
     },
     "node_modules/typescript": {
@@ -7399,7 +7614,6 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -7744,6 +7958,25 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.3.tgz",
+      "integrity": "sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
+    },
+    "node_modules/webrtc-issue-detector": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/webrtc-issue-detector/-/webrtc-issue-detector-1.17.0.tgz",
+      "integrity": "sha512-8rgQs1UE3Rw18iiowcb1NRS8ZI2G30U6GrRHTjEGtyOJK6hcuNpDmax09ffFSzuHC6orc0WlbBw6ZJFr+c6/yQ==",
+      "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@fullcalendar/react": "^6.1.18",
     "@fullcalendar/timegrid": "^6.1.18",
     "@google/genai": "^1.10.0",
+    "@heygen/streaming-avatar": "^2.0.16",
     "@hookform/resolvers": "^5.2.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/src/component/sidebar/SidebarBody.tsx
+++ b/src/component/sidebar/SidebarBody.tsx
@@ -1,5 +1,5 @@
 import { useSidebarStore } from "@/stores/sidebar/sidebarStore";
-import { Home, LayoutTemplate, Star, User, CalendarRange } from "lucide-react";
+import { Home, LayoutTemplate, Star, User, CalendarRange, Bot } from "lucide-react";
 import { NavLink } from "react-router-dom";
 
 export const SidebarBody = () => {
@@ -82,6 +82,21 @@ export const SidebarBody = () => {
           >
             <CalendarRange size={20} />
             {!isCollapsed && <span className="text-sm font-medium">Session de travail</span>}
+          </NavLink>
+        </li>
+        <li>
+          <NavLink
+            to="/dashboard/avatar"
+            className={({ isActive }) =>
+              `px-4 py-2 flex items-center transition-all duration-300 ease-in-out transform hover:scale-96 ${
+                isCollapsed ? "justify-center" : "gap-3"
+              } hover:bg-gray-700 hover:shadow-lg ${
+                isActive ? "bg-gradient-to-r from-[#334155] to-[#141e32] rounded-l-xl shadow-md" : ""
+              }`
+            }
+          >
+            <Bot size={20} />
+            {!isCollapsed && <span className="text-sm font-medium">Avatar</span>}
           </NavLink>
         </li>
       </ul>

--- a/src/modules/heygen/HeygenQuestAvatar.tsx
+++ b/src/modules/heygen/HeygenQuestAvatar.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from "react";
+import StreamingAvatar, { AvatarQuality, StreamingEvents, STTProvider } from "@heygen/streaming-avatar";
+import type { QuestAiType } from "@/shared/types/ai/ai.type";
+import { generateQuestsFromAI } from "@/modules/canvas/generate-quests-from-ai";
+
+/**
+ * HeyGen interactive avatar that listens to user's voice and generates quests
+ * using the existing AI quest generation utilities.
+ */
+export const HeygenQuestAvatar = () => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [status, setStatus] = useState("initialisation en cours...");
+  const [quests, setQuests] = useState<QuestAiType[]>([]);
+
+  useEffect(() => {
+    const startAvatar = async () => {
+      const token = import.meta.env.VITE_HEYGEN_TOKEN as string | undefined;
+      const avatarName = import.meta.env.VITE_HEYGEN_AVATAR as string | undefined;
+      const voiceId = import.meta.env.VITE_HEYGEN_VOICE as string | undefined;
+
+      if (!token || !avatarName) {
+        setStatus("Token HeyGen ou avatar manquant");
+        return;
+      }
+
+      const client = new StreamingAvatar({ token });
+      let buffer = "";
+
+      client.on(StreamingEvents.STREAM_READY, () => {
+        setStatus("Prêt");
+        if (videoRef.current && client.mediaStream) {
+          videoRef.current.srcObject = client.mediaStream;
+        }
+      });
+
+      client.on(StreamingEvents.USER_TALKING_MESSAGE, (e) => {
+        buffer += e.message;
+      });
+
+      client.on(StreamingEvents.USER_END_MESSAGE, async () => {
+        const instruction = buffer.trim();
+        buffer = "";
+        if (instruction) {
+          const newQuests = await generateQuestsFromAI({
+            instruction,
+            aiProvider: "openai",
+            existingQuests: [],
+            format: {},
+          });
+          setQuests(newQuests);
+        }
+      });
+
+      await client.createStartAvatar({
+        avatarName,
+        quality: AvatarQuality.Medium,
+        voice: voiceId ? { voiceId } : undefined,
+        sttSettings: { provider: STTProvider.DEEPGRAM },
+      });
+
+      await client.startVoiceChat({ isInputAudioMuted: false });
+    };
+
+    startAvatar();
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4">
+      <video ref={videoRef} autoPlay playsInline className="w-64 h-64 rounded-lg bg-black" />
+      <p className="text-white text-sm">{status}</p>
+      {quests.length > 0 && (
+        <div className="w-full max-w-md text-left text-white">
+          <h3 className="text-lg font-semibold mb-2">Quêtes générées</h3>
+          <ul className="space-y-2">
+            {quests.map((q, idx) => (
+              <li key={idx} className="p-2 rounded bg-slate-800">
+                <h4 className="font-medium">{q.title}</h4>
+                <p className="text-sm">{q.description}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HeygenQuestAvatar;

--- a/src/pages/dashboard/Avatar.tsx
+++ b/src/pages/dashboard/Avatar.tsx
@@ -1,0 +1,11 @@
+import HeygenQuestAvatar from "@/modules/heygen/HeygenQuestAvatar";
+
+export const Avatar = () => {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+      <HeygenQuestAvatar />
+    </div>
+  );
+};
+
+export default Avatar;

--- a/src/routes/router.const.ts
+++ b/src/routes/router.const.ts
@@ -11,6 +11,7 @@ export interface IRoutes {
   store: IRoute;
   canvas: IRoute;
   workSession: IRoute;
+  avatar: IRoute;
   notfound: IRoute;
 }
 
@@ -34,6 +35,10 @@ export const routes: IRoutes = {
   store: {
     path: "/dashboard/store",
     display: "Store",
+  },
+  avatar: {
+    path: "/dashboard/avatar",
+    display: "Avatar",
   },
   canvas: {
     path: "/canvas",

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -8,6 +8,7 @@ import { Skills } from "@/pages/dashboard/Skills";
 import { SkillDetail } from "@/modules/skills/components/SkillDetail";
 import { Profil } from "@/pages/dashboard/Profil";
 import { Store } from "@/pages/dashboard/Store";
+import { Avatar } from "@/pages/dashboard/Avatar";
 import { NotFoundPage } from "@/pages/404";
 import { WorkSession } from "@/pages/dashboard/WorkSession";
 
@@ -38,6 +39,10 @@ export const router = createBrowserRouter([
           {
             path: routes.store.path,
             element: <Store />,
+          },
+          {
+            path: routes.avatar.path,
+            element: <Avatar />,
           },
           {
             path: routes.workSession.path,


### PR DESCRIPTION
## Summary
- integrate HeyGen streaming avatar component that listens to user voice and generates quests via existing AI utility
- expose avatar on new dashboard route with sidebar link
- add HeyGen env vars and dependency

## Testing
- `npm run prettier`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a760b8128c8320965ea30d6f67bc3d