### PR TITLE
feat: add interactive onboarding for canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.61.1",
+        "react-joyride": "^2.5.3",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.6.2",
         "sonner": "^2.0.2",
@@ -1393,6 +1394,12 @@
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.19"
       }
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.1.2.tgz",
+      "integrity": "sha512-jk+qzItoEb0D0xSSmrKDDzf9sheQj/BAPxlgNxgmOaA3mxpUa6ndJLYGZKsJnIVEQSD8zcTbyILz7I0HcnBCRA==",
+      "license": "MIT"
     },
     "node_modules/@google/genai": {
       "version": "1.14.0",
@@ -4089,6 +4096,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -4605,6 +4621,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5197,6 +5219,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-lite": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.9.3.tgz",
+      "integrity": "sha512-lbyynwsRRUMh1fHEinXkde/thdjj8OpW/okyGAVgmW4r/FkCEP966oSEg0B8ON5+mm73MJjFXB4ZViuaAldw4g==",
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5283,7 +5311,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5756,6 +5783,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -6545,6 +6584,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/openai": {
       "version": "5.12.2",
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
@@ -6712,6 +6760,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -6774,6 +6833,17 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
       }
     },
     "node_modules/property-information": {
@@ -6853,6 +6923,56 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-joyride": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-2.5.3.tgz",
+      "integrity": "sha512-DKKvb/JAAsHm0x/RWO3WI6NOtTMHDso5v8MTauxTSz2dFs7Tu1rWg1BDBWmEMj6pUCvem7hblFbCiDAcvhs8tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "exenv": "^1.2.2",
+        "is-lite": "^0.9.2",
+        "prop-types": "^15.8.1",
+        "react-floater": "^0.7.6",
+        "react-is": "^16.13.1",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.0.1",
+        "tree-changes": "^0.9.2"
+      },
+      "peerDependencies": {
+        "react": "15 - 18",
+        "react-dom": "15 - 18"
+      }
+    },
+    "node_modules/react-joyride/node_modules/react-floater": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.7.9.tgz",
+      "integrity": "sha512-NXqyp9o8FAXOATOEo0ZpyaQ2KPb4cmPMXGWkx377QtJkIXHlHRAGer7ai0r0C1kG5gf+KJ6Gy+gdNIiosvSicg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.3.1",
+        "is-lite": "^0.8.2",
+        "popper.js": "^1.16.0",
+        "prop-types": "^15.8.1",
+        "tree-changes": "^0.9.1"
+      },
+      "peerDependencies": {
+        "react": "15 - 18",
+        "react-dom": "15 - 18"
+      }
+    },
+    "node_modules/react-joyride/node_modules/react-floater/node_modules/is-lite": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.8.2.tgz",
+      "integrity": "sha512-JZfH47qTsslwaAsqbMI3Q6HNNjUuq6Cmzzww50TdP5Esb6e1y2sK2UAaZZuzfAzpoI2AkxoPQapZdlDuP6Vlsw==",
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7160,6 +7280,18 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+      "license": "MIT"
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -7493,6 +7625,22 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tree-changes": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.9.3.tgz",
+      "integrity": "sha512-vvvS+O6kEeGRzMglTKbc19ltLWNtmNt1cpBoSYLj/iEcPVvpJasemKOlxBrmZaCtDJoF+4bwv3m01UKYi8mukQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.1.1",
+        "is-lite": "^0.8.2"
+      }
+    },
+    "node_modules/tree-changes/node_modules/is-lite": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.8.2.tgz",
+      "integrity": "sha512-JZfH47qTsslwaAsqbMI3Q6HNNjUuq6Cmzzww50TdP5Esb6e1y2sK2UAaZZuzfAzpoI2AkxoPQapZdlDuP6Vlsw==",
       "license": "MIT"
     },
     "node_modules/trim-lines": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.61.1",
+    "react-joyride": "^2.5.3",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.6.2",
     "sonner": "^2.0.2",

--- a/src/modules/canvas/Canvas.tsx
+++ b/src/modules/canvas/Canvas.tsx
@@ -18,6 +18,7 @@ import { initialNodes } from "./canvas.const";
 import { useAddAIQuests } from "./hooks/useAddAIQuest";
 import { QuestDetailsModal } from "./components/quest-card-component/QuestDetailsModal";
 import { CanvasLoader } from "./components/CanvasLoader";
+import { CanvasOnboarding } from "./components/CanvasOnboarding";
 
 export const Canvas = () => {
   const [connectionStart, setConnectionStart] = useState<string | null>(null);
@@ -143,6 +144,7 @@ export const Canvas = () => {
       <QuestDetailsModal open={isQuestModalOpen} quest={selectedQuest} onClose={() => setIsQuestModalOpen(false)} />
 
       <Toaster position="bottom-right" />
+      <CanvasOnboarding />
     </div>
   );
 };

--- a/src/modules/canvas/components/CanvasOnboarding.tsx
+++ b/src/modules/canvas/components/CanvasOnboarding.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import Joyride, { CallBackProps, STATUS, Step } from "react-joyride";
+import { useCanvasStore } from "@/stores/canvas/canvas-store";
+
+export const CanvasOnboarding = () => {
+  const [run, setRun] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+
+  const cursorMode = useCanvasStore((s) => s.cursorMode);
+  const nodeCount = useCanvasStore((s) => s.nodes.length);
+  const edgeCount = useCanvasStore((s) => s.edges.length);
+
+  useEffect(() => {
+    const hasSeen = localStorage.getItem("canvas_onboarding_done");
+    if (!hasSeen) {
+      setRun(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!run) return;
+
+    if (stepIndex === 1 && cursorMode === "create") {
+      setStepIndex(2);
+    }
+    if (stepIndex === 2 && nodeCount >= 1) {
+      setStepIndex(3);
+    }
+    if (stepIndex === 3 && nodeCount >= 2) {
+      setStepIndex(4);
+    }
+    if (stepIndex === 4 && cursorMode === "connect") {
+      setStepIndex(5);
+    }
+    if (stepIndex === 5 && edgeCount >= 1) {
+      setStepIndex(6);
+    }
+  }, [cursorMode, nodeCount, edgeCount, stepIndex, run]);
+
+  const handleJoyrideCallback = (data: CallBackProps) => {
+    const { status, index, type } = data;
+    const finishedStatuses = [STATUS.FINISHED, STATUS.SKIPPED];
+
+    if (finishedStatuses.includes(status)) {
+      setRun(false);
+      localStorage.setItem("canvas_onboarding_done", "true");
+      return;
+    }
+
+    if (type === "step:after" || type === "target:notFound") {
+      setStepIndex(index + 1);
+    }
+  };
+
+  const steps: Step[] = [
+    {
+      target: '[data-tour="toolbox"]',
+      content:
+        "La boîte à outils vous permet de créer et de relier des quêtes. Cliquer sur une icône change le mode du curseur.",
+      disableBeacon: true,
+    },
+    {
+      target: '[data-tour="create"]',
+      content: "Sélectionnez l'outil de création pour ajouter une quête.",
+      spotlightClicks: true,
+    },
+    {
+      target: '[data-tour="canvas"]',
+      content: "Cliquez sur le canvas pour créer votre première quête.",
+      spotlightClicks: true,
+      placement: "center",
+    },
+    {
+      target: '[data-tour="canvas"]',
+      content: "Créez une deuxième quête pour pouvoir les relier.",
+      spotlightClicks: true,
+      placement: "center",
+    },
+    {
+      target: '[data-tour="connect"]',
+      content: "Passez à l'outil de connexion pour relier vos quêtes.",
+      spotlightClicks: true,
+    },
+    {
+      target: '[data-tour="canvas"]',
+      content: "Cliquez sur deux quêtes pour créer un lien entre elles.",
+      spotlightClicks: true,
+      placement: "center",
+    },
+    {
+      target: '[data-tour="minimap"]',
+      content: "La mini-carte offre une vue globale du canvas.",
+    },
+    {
+      target: '[data-tour="controls"]',
+      content: "Utilisez ces contrôles pour zoomer ou ajuster la vue.",
+    },
+    {
+      target: '[data-tour="roadmap"]',
+      content: "Accédez à la roadmap complète de vos compétences ici.",
+    },
+    {
+      target: '[data-tour="canvas"]',
+      content: "Ceci est votre zone de création. Cliquez ou faites glisser pour explorer et construire votre parcours.",
+      placement: "center",
+    },
+  ];
+
+  return (
+    <Joyride
+      steps={steps}
+      run={run}
+      stepIndex={stepIndex}
+      showSkipButton
+      disableOverlayClose
+      spotlightClicks
+      callback={handleJoyrideCallback}
+      styles={{ options: { zIndex: 10000 } }}
+    />
+  );
+};

--- a/src/modules/canvas/components/CanvasView.tsx
+++ b/src/modules/canvas/components/CanvasView.tsx
@@ -73,6 +73,8 @@ export const CanvasView = ({
 
   return (
     <ReactFlow
+      id="canvas-root"
+      data-tour="canvas"
       onInit={(reactFlowInstance) => {
         reactFlowInstance.setViewport({ x: 0, y: 0, zoom: 0.5 }, { duration: 800 });
       }}
@@ -101,23 +103,27 @@ export const CanvasView = ({
     >
       <Background color="#aaa" gap={30} size={0.5} />
 
-      <Controls position="bottom-right" />
+      <div data-tour="controls">
+        <Controls position="bottom-right" />
+      </div>
 
-      <MiniMap
-        nodeStrokeWidth={2}
-        position="bottom-left"
-        nodeColor={(node) => {
-          return node.type === "skill" ? "#3b82f6" : "#10b981";
-        }}
-        style={{
-          backgroundColor: "rgba(12, 8, 33, 0.8)",
-          border: "2px solid rgba(59, 130, 246, 0.3)",
-          borderRadius: "12px",
-          backdropFilter: "blur(8px)",
-        }}
-        maskColor="rgba(12, 8, 33, 0.4)"
-        className="shadow-2xl "
-      />
+      <div data-tour="minimap">
+        <MiniMap
+          nodeStrokeWidth={2}
+          position="bottom-left"
+          nodeColor={(node) => {
+            return node.type === "skill" ? "#3b82f6" : "#10b981";
+          }}
+          style={{
+            backgroundColor: "rgba(12, 8, 33, 0.8)",
+            border: "2px solid rgba(59, 130, 246, 0.3)",
+            borderRadius: "12px",
+            backdropFilter: "blur(8px)",
+          }}
+          maskColor="rgba(12, 8, 33, 0.4)"
+          className="shadow-2xl "
+        />
+      </div>
 
       <div className="absolute top-6 left-4 z-20">
         <Button
@@ -144,7 +150,9 @@ export const CanvasView = ({
           expandAll={expandAll}
           setOpenAiModal={setOpenAiModal}
         />
-        <RoadmapButton onClick={() => setViewMode("skillTree")} />
+        <div data-tour="roadmap">
+          <RoadmapButton onClick={() => setViewMode("skillTree")} />
+        </div>
       </div>
 
       {openAiModal && <AIQuestGenerationModal onGenerate={openAIGenerator} setOpenAiModal={setOpenAiModal} />}

--- a/src/modules/canvas/components/floating-toolbox/FloatingToolbox.tsx
+++ b/src/modules/canvas/components/floating-toolbox/FloatingToolbox.tsx
@@ -81,6 +81,7 @@ export const FloatingToolbox = ({
 
   return (
     <div
+      data-tour="toolbox"
       className={` rounded-xl shadow-lg flex flex-col gap-1 bg-[rgba(15,10,40,0.85)] border-2 border-[rgba(59,130,246,0.4)] backdrop-blur-md transition-all duration-300 ease-in-out ${
         isToolboxCollapsed ? "w-14 p-1" : "w-auto p-2"
       }`}

--- a/src/modules/canvas/components/floating-toolbox/ToolButton.tsx
+++ b/src/modules/canvas/components/floating-toolbox/ToolButton.tsx
@@ -27,6 +27,7 @@ export const ToolButton = ({ tool, cursorMode, setCursorMode, context }: ToolBut
         className={`w-10 h-10 p-0 cursor-pointer rounded-lg transition-all duration-200 ${
           active ? tool.activeColor + " shadow-md" : "hover:bg-gray-100"
         }`}
+        data-tour={tool.id}
       >
         {tool.icon}
       </Button>


### PR DESCRIPTION
## Summary
- expand canvas onboarding with interactive steps to create and link first quests
- watch cursor mode, node and edge creation to advance tutorial

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be16209cf48320988e21d1e6ac2b85